### PR TITLE
Tests fail with HTTP::Parser > 0.06

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,7 +14,7 @@ Test::POE::Server::TCP = 0.16
 
 [Prereq]
 Encode = 0
-HTTP::Parser = 0.04
+HTTP::Parser = 0.06
 HTTP::Request = 0
 HTTP::Response = 0
 HTTP::Status = 0

--- a/t/01_filter_req.t
+++ b/t/01_filter_req.t
@@ -27,6 +27,6 @@ foreach my $test ( $filter, $clone ) {
    foreach my $req ( @$events ) {
      isa_ok( $req, 'HTTP::Request' );
      is( $req->method, 'GET', 'Request method was okay' );
-     is( $req->uri->as_string, '/', 'The URI was okay' );
+     is( $req->uri->path, '/', 'The URI was okay' );
    }
 }

--- a/t/02_in_use.t
+++ b/t/02_in_use.t
@@ -73,7 +73,7 @@ sub httpd_client_input {
   my $test = delete $heap->{current_test};
   isa_ok( $req, 'HTTP::Request' );
   is( $req->method, 'GET', 'Request method is GET' );
-  is( $req->uri->as_string, $test, 'Correct path' );
+  is( $req->uri->path, $test, 'Correct path' );
   is( $req->header('X-HTTP-Version'), '1.1', 'X-HTTP-Version' );
   diag($req->as_string);
   my $resp = HTTP::Response->new( 200 );


### PR DESCRIPTION
HTTP::Parser 0.06 changed the way it creates its URI object so that it can handle path fragments that begin with a `//`, and as a result `$request->uri->as_string` for the path `/` now returns `///` (schemeless uri).  The tests actually wanted `$uri->path`, so I updated them.
